### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ ./scripts/deploy_gradle.sh
 
 The script will create a Service Registry service instance and then push the applications and bind them to the service.
 
-When the script has finished, set the `TRUST_CERTS` environment variable to the API endpoint of your Elastic Runtime instance (as in `api.example.com`), then restage the applications so that the changes will take effect. Setting `TRUST_CERTS` causes Spring Cloud Services to add the the SSL certificate at the specfied API endpoint to the JVM's truststore, so that the client application can communicate with a Service Registry service instance even if your Elastic Runtime instance is using a self-signed SSL certificate (see the [Service Registry Documentation](http://docs.pivotal.io/spring-cloud-services/service-registry/writing-client-applications.html#self-signed-ssl-certificate).
+When the script has finished, set the `TRUST_CERTS` environment variable to the API endpoint of your Elastic Runtime instance (as in `api.example.com`), then restage the applications so that the changes will take effect. Setting `TRUST_CERTS` causes Spring Cloud Services to add the the SSL certificate at the specfied API endpoint to the JVM's truststore, so that the client application can communicate with a Service Registry service instance even if your Elastic Runtime instance is using a self-signed SSL certificate (see the [Service Registry Documentation](https://docs.pivotal.io/spring-cloud-services/service-registry/writing-client-applications.html#self-signed-ssl-certificate).
 
 ```
 $ cf set-env homeowner TRUST_CERTS api.wise.com
@@ -38,7 +38,7 @@ $ cf restage visitor
 
 **NOTE**
 
-> By default, the Spring Cloud Services Starters for Service Registry causes all application endpoints to be secured by HTTP Basic authentication. For more information or if you wish to disable this, [see the documentation](http://docs.pivotal.io/spring-cloud-services/service-registry/writing-client-applications.html#disable-http-basic-auth). HTTP Basic authentication is disabled in these sample applications.
+> By default, the Spring Cloud Services Starters for Service Registry causes all application endpoints to be secured by HTTP Basic authentication. For more information or if you wish to disable this, [see the documentation](https://docs.pivotal.io/spring-cloud-services/service-registry/writing-client-applications.html#disable-http-basic-auth). HTTP Basic authentication is disabled in these sample applications.
 
 ## Trying It Out
 
@@ -60,4 +60,4 @@ After responding in the text field what the name of the visitor is then you will
 
 <img src="docs/images/circuit-open-greeting-response.png" width="50%"/>
 
-For more information about the Service Registry and its use in a client application, see the [Service Registry documentation](http://docs.pivotal.io/spring-cloud-services/service-registry/writing-client-applications.html).
+For more information about the Service Registry and its use in a client application, see the [Service Registry documentation](https://docs.pivotal.io/spring-cloud-services/service-registry/writing-client-applications.html).

--- a/visitor/src/main/resources/templates/greeting.html
+++ b/visitor/src/main/resources/templates/greeting.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 
 <head>
     <title th:text="|Knock! Knock!|">Who is Home?</title>

--- a/visitor/src/main/resources/templates/knock.html
+++ b/visitor/src/main/resources/templates/knock.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 
 <head>
     <title th:text="|Knock! Knock!|">Who is Home?</title>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.thymeleaf.org with 2 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).
* [ ] http://docs.pivotal.io/spring-cloud-services/service-registry/writing-client-applications.html with 3 occurrences migrated to:  
  https://docs.pivotal.io/spring-cloud-services/service-registry/writing-client-applications.html ([https](https://docs.pivotal.io/spring-cloud-services/service-registry/writing-client-applications.html) result 301).